### PR TITLE
Fix clean shutdown issue.

### DIFF
--- a/pcap.js
+++ b/pcap.js
@@ -113,6 +113,10 @@ PcapSession.prototype.close = function () {
     this.removeAllListeners();
 
     this.session.close();
+
+    if (this.is_live) {
+      process.nextTick(this.session.read_callback);
+    }
 };
 
 PcapSession.prototype.stats = function () {


### PR DESCRIPTION
It's possible read_callback will never be called after close if we never receive a packet which triggers it. That means the native code never calls FinalizeClose to cleanly shut everything down, leaving the native polling using memory we will gc at some point in the future (never good). To avoid this, force a callback now.